### PR TITLE
Don't rely on debugging bash features

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export PACKMAN_ROOT=$(cd $(dirname $BASH_ARGV) && pwd)
+export PACKMAN_ROOT=$(cd $(dirname $0) && pwd)
 export PATH=$PACKMAN_ROOT:$PATH
 
 # Set command line completion for packman command


### PR DESCRIPTION
Per the bash documentation (http://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html):

> The shell sets BASH_ARGV only when in extended debugging mode.
> Therefore, we should use $0 to get the first command (i.e. the script name) rather than all arguments.

Other than that, looks awesome!
