### PR TITLE
Use the system bash instead of hardcoding

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export PACKMAN_ROOT=$(cd $(dirname $BASH_ARGV) && pwd)
 export PATH=$PACKMAN_ROOT:$PATH


### PR DESCRIPTION
I don't like using the outdated mac binary of bash.  Rather than hardcoding to /bin, use the env command to get the highest-priority bash.
